### PR TITLE
Remove ace_tools dependency and save scraped news to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Yahoo Finance Scraper
 
 ## Descrição
-Este projeto faz scraping de notícias financeiras do Yahoo Finance. Ele coleta títulos, links e exibe os dados em um DataFrame.
+Este projeto faz scraping de notícias financeiras do Yahoo Finance. Ele coleta títulos e links, exibe um preview no console e salva os dados em um arquivo CSV.
 
 ## Instalação
 1. Clone este repositório:
@@ -23,12 +23,13 @@ python scraper.py
 
 O script tentará conectar até 3 vezes caso haja falhas na requisição.
 
+As primeiras linhas do resultado serão exibidas no terminal e um arquivo `dados/noticias_yahoo.csv` será gerado com todas as notícias coletadas.
+
 ## Tecnologias Utilizadas
 - Python
 - Requests
 - BeautifulSoup
 - Pandas
-- Ace Tools
 
 ## Contribuição
 Contribuições são bem-vindas! Para sugerir melhorias, abra uma issue ou faça um pull request.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 beautifulsoup4
 pandas
-ace_tools

--- a/scraper.py
+++ b/scraper.py
@@ -8,6 +8,7 @@ número máximo de tentativas de requisição via argumentos de linha de comando
 
 import time
 from urllib.parse import urljoin, urlparse
+import os
 
 import pandas as pd
 import requests
@@ -88,13 +89,9 @@ if __name__ == "__main__":
 
     df = scrape_news(url=args.url, max_retries=args.max_retries)
     if df is not None:
-        try:
-            import ace_tools as tools
-
-            tools.display_dataframe_to_user(name="Notícias Yahoo Finance", dataframe=df)
-        except ModuleNotFoundError:
-            # Exibe as primeiras linhas se a ferramenta não estiver disponível
-            print(df.head())
+        os.makedirs("dados", exist_ok=True)
+        df.to_csv("dados/noticias_yahoo.csv", index=False)
+        print(df.head())
     else:
         print("Erro ao acessar Yahoo Finance ou resposta inválida.")
 


### PR DESCRIPTION
## Summary
- drop optional ace_tools dependency and rely on pandas output
- write scraped news to dados/noticias_yahoo.csv and show a preview in terminal
- update README and requirements

## Testing
- `python scraper.py --max_retries 1` *(fails: HTTPSConnectionPool(host='finance.yahoo.com', port=443): Max retries exceeded with url: /news/ (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68c50689a1c0832b9b440831f7b3050a