### PR TITLE
Save scraped news to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ python scraper.py
 
 O script tentará conectar até 3 vezes caso haja falhas na requisição.
 
+Os resultados são gravados por padrão em `dados/noticias_yahoo.csv`. Para
+alterar o caminho de saída, utilize o parâmetro `--output`:
+
+```bash
+python scraper.py --output caminho/para/arquivo.csv
+```
+
 ## Tecnologias Utilizadas
 - Python
 - Requests

--- a/scraper.py
+++ b/scraper.py
@@ -6,6 +6,7 @@ resultados. Quando executado como script, o usuário pode ajustar a URL e o
 número máximo de tentativas de requisição via argumentos de linha de comando.
 """
 
+import os
 import time
 from urllib.parse import urljoin, urlparse
 
@@ -84,10 +85,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--max_retries", type=int, default=MAX_RETRIES, help="Número máximo de tentativas"
     )
+    parser.add_argument(
+        "--output",
+        default="dados/noticias_yahoo.csv",
+        help="Caminho para salvar o CSV de saída",
+    )
     args = parser.parse_args()
 
     df = scrape_news(url=args.url, max_retries=args.max_retries)
     if df is not None:
+        # Garante que o diretório exista antes de salvar
+        os.makedirs(os.path.dirname(args.output), exist_ok=True)
+        df.to_csv(args.output, index=False)
+
         try:
             import ace_tools as tools
 


### PR DESCRIPTION
## Summary
- allow specifying CSV output path for scraped news
- ensure output directory exists before saving
- document default CSV location and `--output` usage in README

## Testing
- `python scraper.py` *(fails: 403 Forbidden connecting to Yahoo Finance)*

------
https://chatgpt.com/codex/tasks/task_e_68c5068bba34832bbf476757e2399e74