### PR TITLE
Remove duplicate os import in scraper.py

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -9,7 +9,6 @@ número máximo de tentativas de requisição via argumentos de linha de comando
 import os
 import time
 from urllib.parse import urljoin, urlparse
-import os
 
 import pandas as pd
 import requests


### PR DESCRIPTION
## Summary
- remove redundant second `import os`

## Testing
- `python -m pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c509ac6b40832b80979e180783c8c4