### PR TITLE
Evita criar diretório vazio ao salvar saída

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -96,7 +96,9 @@ if __name__ == "__main__":
     if df is not None:
 
         # Garante que o diretório exista antes de salvar
-        os.makedirs(os.path.dirname(args.output), exist_ok=True)
+        dirpath = os.path.dirname(args.output)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
         df.to_csv(args.output, index=False)
 
         try:


### PR DESCRIPTION
## Summary
- Evita chamada desnecessária a `os.makedirs` quando `--output` não inclui diretório

## Testing
- `python -m py_compile scraper.py`
- ⚠️ `python scraper.py --url https://example.com --max_retries 1 --output /tmp/test.csv` (falhou: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c50a633830832bbf23cd0571b09707