### PR TITLE
Refine Yahoo Finance headline scraping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 pandas
+pytest

--- a/scraper.py
+++ b/scraper.py
@@ -18,6 +18,7 @@ from bs4 import BeautifulSoup
 BASE_URL = "https://finance.yahoo.com"
 URL = urljoin(BASE_URL, "news/")
 HEADERS = {"User-Agent": "Mozilla/5.0"}  # Evita bloqueios
+NEWS_HEADLINE_SELECTOR = "li.js-stream-content h3 a"
 
 # Tentativa de conexão com retries
 MAX_RETRIES = 3
@@ -55,13 +56,13 @@ def scrape_news(url: str = URL, max_retries: int = MAX_RETRIES) -> pd.DataFrame 
     if response and response.status_code == 200:
         soup = BeautifulSoup(response.text, "html.parser")
 
-        # Encontrando os blocos de notícia
-        articles = soup.find_all("h3")  # Yahoo usa <h3> para manchetes
+        # Encontrando somente as manchetes dentro dos blocos de notícia
+        articles = soup.select(NEWS_HEADLINE_SELECTOR)
 
         news_data = []
         for article in articles:
-            title = article.text
-            href = article.a.get("href") if article.a else ""
+            title = article.get_text(strip=True)
+            href = article.get("href") or ""
             if href:
                 full_url = urljoin(BASE_URL, href)
                 parsed = urlparse(full_url)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from unittest.mock import Mock, patch
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scraper import scrape_news, NEWS_HEADLINE_SELECTOR
+
+SAMPLE_HTML = '''
+<ul>
+  <li class="js-stream-content">
+    <h3 class="Mb(5px)"><a href="/news/foo">Foo</a></h3>
+  </li>
+  <li class="js-stream-content">
+    <h3 class="Mb(5px)"><a href="/news/bar">Bar</a></h3>
+  </li>
+  <li>
+    <h3><a href="/other">Other</a></h3>
+  </li>
+</ul>
+'''
+
+def test_scrape_news_uses_specific_selector():
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = SAMPLE_HTML
+    mock_response.raise_for_status = Mock()
+    with patch('requests.get', return_value=mock_response):
+        df = scrape_news(url='http://test', max_retries=1)
+    assert isinstance(df, pd.DataFrame)
+    assert df['Título'].tolist() == ['Foo', 'Bar']
+    assert df['Link'].tolist() == [
+        'https://finance.yahoo.com/news/foo',
+        'https://finance.yahoo.com/news/bar'
+    ]


### PR DESCRIPTION
## Summary
- Target Yahoo Finance news headlines using a specific CSS selector
- Add unit test to validate scraping with mocked markup
- Include pytest in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50b3c3aa0832b936cd943367bc017